### PR TITLE
Wrong OIDC issuer value

### DIFF
--- a/environments/common.yaml.gotmpl
+++ b/environments/common.yaml.gotmpl
@@ -75,7 +75,7 @@ orchestrate:
   
   auth:
     jwt:
-      issuerUrl: https://consensys.eu.auth0.com
+      issuerUrl: https://consensys.eu.auth0.com/
       audience: https://orchestrate.consensys.net
       claims: https://api.orchestrate.network
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines -->

## PR Description

- oidc issuer url is missing trailing "/"

## Documentation

- [ ] I thought about documentation and added the `documentation` label to this PR if updates are required.
